### PR TITLE
Refactor product functions

### DIFF
--- a/YOUR_ADMIN/includes/functions/extra_functions/usu.php
+++ b/YOUR_ADMIN/includes/functions/extra_functions/usu.php
@@ -55,6 +55,44 @@ function usu_reset_cache_data($value)
     return 'false';
 }
 
+if (!function_exists('zen_product_in_category')) {
+
+	function zen_product_in_category($product_id, $cat_id)
+	{
+		global $db;
+		$in_cat = false;
+		$category_query_raw = "select categories_id from " . TABLE_PRODUCTS_TO_CATEGORIES . "
+                           where products_id = '" . (int)$product_id . "'";
+
+		$category = $db->Execute($category_query_raw);
+
+		while (!$category->EOF) {
+			if ($category->fields['categories_id'] == $cat_id) {
+				$in_cat = true;
+			}
+			if (!$in_cat) {
+				$parent_categories_query = "select parent_id from " . TABLE_CATEGORIES . "
+                                    where categories_id = '" . $category->fields['categories_id'] . "'";
+
+				$parent_categories = $db->Execute($parent_categories_query);
+//echo 'cat='.$category->fields['categories_id'].'#'. $cat_id;
+
+				while (!$parent_categories->EOF) {
+					if (($parent_categories->fields['parent_id'] != 0)) {
+						if (!$in_cat) {
+							$in_cat = zen_product_in_parent_category($product_id, $cat_id,
+								$parent_categories->fields['parent_id']);
+						}
+					}
+					$parent_categories->MoveNext();
+				}
+			}
+			$category->MoveNext();
+		}
+		return $in_cat;
+	}
+}
+
 // =======================================
 // ==> NOTE: All the following functions are deprecated as of v3.0.1 and will be removed in a future USU release.
 // =======================================

--- a/includes/classes/usu.php
+++ b/includes/classes/usu.php
@@ -595,7 +595,8 @@ class usu
 
 	            if (USU_FORMAT == 'parent' && USU_CATEGORY_DIR == 'off') {
 		            $masterCatID = (int)zen_get_products_category_id($pID);
-		            $pName = $this->get_category_name($cID !== null ? $cID : $masterCatID, 'original') . '-' . $pName;
+		            $category_id = ($cID !== null ? $cID : $masterCatID);
+		            $pName = $this->get_category_name($category_id, 'original') . '-' . $pName;
                 }
 
                 if (is_array($this->cache)) {
@@ -610,7 +611,7 @@ class usu
 	    if (USU_CATEGORY_DIR != 'off') {
 		    if (empty($cID)) {
 			    $masterCatID = (int)zen_get_products_category_id($pID);
-			    $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $masterCatID . '/';
+			    $category = $this->get_category_name($masterCatID) . $this->reg_anchors['cPath'] . $masterCatID . '/';
 		    } else {
 			    if (zen_product_in_category($pID, $cID)) {
 				    $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $cID . '/';

--- a/includes/classes/usu.php
+++ b/includes/classes/usu.php
@@ -580,7 +580,6 @@ class usu
     {
         global $db;
         $pID = (int)$pID;
-        $categories_clause = ($cID !== null) ? (' AND ptc.categories_id = ' . (int)$cID) : '';
         // Handle generating the product name
         switch (true) {
             case (defined('PRODUCT_NAME_' . $pID)):
@@ -606,14 +605,19 @@ class usu
                 break;
         }
 
-        // Add the category
-        if (USU_CATEGORY_DIR != 'off') {
-            $masterCatID = (int)zen_get_products_category_id($pID);
-            $cID = ($cID !== null ? $cID : $masterCatID);
-            $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $cID . '/';
-
-            $return = $category . $return;
-        }
+	    // Add the category
+	    $category = '';
+	    if (USU_CATEGORY_DIR != 'off') {
+		    if (empty($cID)) {
+			    $masterCatID = (int)zen_get_products_category_id($pID);
+			    $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $masterCatID . '/';
+		    } else {
+			    if (zen_product_in_category($pID, $cID)) {
+				    $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $cID . '/';
+			    }
+		    }
+		    $return = $category . $return;
+	    }
 
         return $return;
     }

--- a/includes/classes/usu.php
+++ b/includes/classes/usu.php
@@ -55,7 +55,6 @@ class usu
             'id' => '-ezp-',
         );
 
-
         if (null === self::$unicodeEnabled) {
             self::$unicodeEnabled = (@preg_match('/\pL/u', 'a')) ? true : false;
         }
@@ -609,21 +608,9 @@ class usu
 
         // Add the category
         if (USU_CATEGORY_DIR != 'off') {
-            $sql = 
-                "SELECT ptc.categories_id AS c_id, p.master_categories_id AS master_id
-                   FROM " . TABLE_PRODUCTS . " p
-                        LEFT JOIN " . TABLE_PRODUCTS_TO_CATEGORIES . " AS ptc
-                            ON ptc.products_id = p.products_id
-                  WHERE p.products_id = $pID" . $categories_clause . "
-                  LIMIT 1";
-
-
-            $result = $db->Execute($sql, false, true, 43200);
-            $category = '';
-            if (!$result->EOF) {
-                $cID = ($cID !== null ? $cID : (int)$result->fields['master_id']);
-                $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $cID . '/';
-            }
+            $masterCatID = (int)zen_get_products_category_id($pID);
+            $cID = ($cID !== null ? $cID : $masterCatID);
+            $category = $this->get_category_name($cID) . $this->reg_anchors['cPath'] . $cID . '/';
 
             $return = $category . $return;
         }


### PR DESCRIPTION
hi cindy,
i broke out the sql into a separate function because i thought i was going to use it more than once.  apparently i found the other 2 functions do not require it.

for those of us that may modify `zen_get_products_name`, these changes prevent the need to do any modification here in `usu`.  which i personally like.

i have done testing php 7.4 and php 8; i had some problems in php8.  those problems were related to the `zen_get_products_name` which i do not think is relavant here.  i did not make use of any of the new coalesce functions in php7; so no reason to think it would not work in earlier versions in which usu already has worked.

my intention was to NOT change any of the logic.  this branch should do exactly the same thing as the master branch.

if that is not the case, by all means let me know, and i will explore.

i did not test the speed or the number of db hits; considering the cache usage i would think this not so important.  it is entirely possible that i may have a tad more db hits and be a tad slower; perhaps this branch is faster....  i would think the cache generation may be slower...

best.

(ps i hope i did not screw up the formatting too bad!)